### PR TITLE
A minor update on the script/sub/00_yum.sh

### DIFF
--- a/script/sub/00_yum.sh
+++ b/script/sub/00_yum.sh
@@ -5,8 +5,8 @@ if [ ! -e /etc/redhat-release ] ; then
     echo "Abort since this script assumes Scientific Linux."
     exit 1
 fi
-if ! grep -q 'Scientific Linux release 7.[67] ' /etc/redhat-release ; then
-    echo "The OS version seems not SL 7.6 nor 7.7."
+if ! grep -q 'Scientific Linux release 7.[678] ' /etc/redhat-release ; then
+    echo "The OS version seems not SL 7.6, 7.7 or 7.8."
     echo "Abort since this script assumes this version."
     exit 1
 fi
@@ -22,6 +22,8 @@ while read PKG ; do
     echo "$LIST_ALL" | grep -q "^${PKG}\." || LIST_PKG+=("$PKG")
 done <<EOF
   screen
+  wget
+  patch
   git-all
   gcc
   gcc-c++


### PR DESCRIPTION
Fermilab updated the SL release to 7.8 sometime last week and it's hard to find 7.7 iso now. It seems the 7.7 - 7.8 upgrade includes kernel update and updates of libraries like boost, but it does not update the gcc. 

I created a SL7.8 virtual machine and tested the installation process, it seems everything still works out-of-the-box on a clean SL7.8. Thus I'm making the following 2 minor changes:

1. included SL7.8 in the OS release list
2. added wget and patch in the yum list since it's not included in a clean barebone SL system.