### PR TITLE
enable xrootd support in root

### DIFF
--- a/script/sub/80_root6.sh
+++ b/script/sub/80_root6.sh
@@ -26,7 +26,7 @@ if [ -e /usr/lib/libgif.so -a ! -e /usr/lib64/libgif.so ] ; then
     # but the x86_64 one isn't.  Indeed "spinquestgpvm" is in such situation.
     # Without these options, cmake tries to link the i686 file and thus fails.
 fi
-cmake -DCMAKE_INSTALL_PREFIX=$DIR_INST/root -Dminuit2=on -Droofit=on -Dopengl=on -Ddavix=off $OPT_EXTRA ../root-6.16.00
+cmake -DCMAKE_INSTALL_PREFIX=$DIR_INST/root -Dminuit2=on -Droofit=on -Dopengl=on -Ddavix=off -Dbuiltin_xrootd=on $OPT_EXTRA ../root-6.16.00
 cmake --build . --target install -- -j6
 
 if [ "$SINGULARITY_NAME" -o ${HOSTNAME:0:13} = 'spinquestgpvm' ] ; then


### PR DESCRIPTION
I would like to enable xroot support. This would allow us to stream files from /pnfs with out copying to local storage (using ifdh), while preventing stuck process.

for example

```
[chleung@seaquestgpvm01 ~]$  kx509
Authorizing ...... authorized
Fetching certificate ..... fetched
Your certificate is valid until: Fri Sep 23 17:43:45 2022
[chleung@seaquestgpvm01 ~]$ voms-proxy-init -noregen -rfc -voms fermilab:/fermilab/spinquest/Role=Analysis
[chleung@seaquestgpvm01 ~]$ source /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.20.00/x86_64-centos7-gcc48-opt/bin/thisroot.sh
[chleung@seaquestgpvm01 ~]$ root -l root://fndca1.fnal.gov/pnfs/fnal.gov/usr/e906/ktrackerreco/production_5ea/vertex/r1.7.0/02/09/vertex_020903_r1.7.0.root
root [0]
Attaching file root://fndca1.fnal.gov/pnfs/fnal.gov/usr/e906/ktrackerreco/production_5ea/vertex/r1.7.0/02/09/vertex_020903_r1.7.0.root as _file0...
Warning in <TClass::Init>: no dictionary for class SRawEvent is available
Warning in <TClass::Init>: no dictionary for class Hit is available
Warning in <TClass::Init>: no dictionary for class SRecEvent is available
Warning in <TClass::Init>: no dictionary for class SRecTrack is available
Warning in <TClass::Init>: no dictionary for class SRecDimuon is available
Warning in <TClass::Init>: no dictionary for class Tracklet is available
Warning in <TClass::Init>: no dictionary for class PropSegment is available
Warning in <TClass::Init>: no dictionary for class SignedHit is available
(TFile *) 0x31c22c0
root [1] .q
```
Here I am streaming the data file from /pnfs. Also, I was able to access this file even when the nfs mount is stuck and Abi is having trouble with this specific file on the same machine when he did `root -l /pnfs/...`